### PR TITLE
Fix focus scope loop on floating windows for RoutedCommands

### DIFF
--- a/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
+++ b/source/Components/AvalonDock/Controls/LayoutFloatingWindowControl.cs
@@ -61,6 +61,7 @@ namespace AvalonDock.Controls
 			AllowsTransparencyProperty.OverrideMetadata(typeof(LayoutFloatingWindowControl), new FrameworkPropertyMetadata(false));
 			ContentProperty.OverrideMetadata(typeof(LayoutFloatingWindowControl), new FrameworkPropertyMetadata(null, null, CoerceContentValue));
 			ShowInTaskbarProperty.OverrideMetadata(typeof(LayoutFloatingWindowControl), new FrameworkPropertyMetadata(false));
+			FocusManager.IsFocusScopeProperty.OverrideMetadata(typeof(LayoutFloatingWindowControl), new FrameworkPropertyMetadata(false));
 		}
 
 		protected LayoutFloatingWindowControl(ILayoutElement model)


### PR DESCRIPTION
#3 restored the logical parent of the floating window for bindings to work.

However, this also caused an infinite loop in the `CommandManager` when trying to execute a `RoutedCommand` having a `CommandBinding` set on the parent window.

In the original WPF AvalonDock, the floating window's _content_ was set as a logical child of the `DockingManager`. In our version, the floating window itself is set as a child. This causes the routed command to incorrectly go through the floating window.

The problem is that the floating window has its own focus scope, causing the `CommandManager` to search its parent scope (which is the `MainWindow`) _starting at the focused element_. The focused element being the currently clicked button, part of the child scope... This is the infinite loop.

In the WPF version, the `FloatingWindowContentHost` is a `HwndHost`. This allows the visual tree to be part of the content host, but the logical tree part of the `DockingManager`. In our fork, `FloatingWindowContentHost` is a `Border`, and we can't change its logical child without causing an exception.

I've tried to introduce a new `Decorator`-like which doesn't add its child to the logical tree directly, but to the `DockingManager`. This doesn't work either, because the visual tree is always searched first: the command manager always reaches the floating window before going back to the logical tree to search for a new focus scope.

As a workaround, this PR sets `IsFocusScope` to false instead of the floating window, breaking the loop.